### PR TITLE
Make user able to specify Bobby API URI

### DIFF
--- a/app/src/pkjs/config.json
+++ b/app/src/pkjs/config.json
@@ -133,6 +133,22 @@
         ]
     },
     {
+        "type": "section",
+        "items": [
+           {
+                "type": "heading",
+                "defaultValue": "Advanced"
+           },
+           {
+                "type": "input",
+                "messageKey": "BOBBY_API_URI",
+                "defaultValue": "bobby-api.rebble.io",
+                "label": "Bobby API URI",
+                "description": "Bobby API URI. Only domain root, do not include protocol (e.g. no http://)."
+           }
+        ]
+    },
+    {
         "type": "submit",
         "defaultValue": "Save"
     }

--- a/app/src/pkjs/urls.js
+++ b/app/src/pkjs/urls.js
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
+var getSettings = function() {
+    return JSON.parse(localStorage.getItem('clay-settings')) || {};
+}
 
-exports.QUERY_URL = 'wss://bobby-api.rebble.io/query';
-exports.QUOTA_URL = 'https://bobby-api.rebble.io/quota';
-exports.FEEDBACK_URL = 'https://bobby-api.rebble.io/feedback';
-exports.REPORT_URL = 'https://bobby-api.rebble.io/report';
+var settings = getSettings();
+var BOBBY_API_URI = settings['BOBBY_API_URI'];
+
+exports.QUERY_URL = 'wss://' + BOBBY_API_URI + '/query';
+exports.QUOTA_URL = 'https://' + BOBBY_API_URI + '/quota';
+exports.FEEDBACK_URL = 'https://' + BOBBY_API_URI + '/feedback';
+exports.REPORT_URL = 'https://' + BOBBY_API_URI + '/report';
 
 var override = require('./urls_override');
 


### PR DESCRIPTION
Since it's possible to self host the Bobby Assistant service, I made a new portion of the settings page to specify your self-hosted server without needing to re-compile the pbw.