### PR TITLE
Fix an issue where transcribed prompts containing double quotes cause…

### DIFF
--- a/app/src/c/util/strings.c
+++ b/app/src/c/util/strings.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Steffan Robert William Donal
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+void strings_fix_android_bridge_bodge(char* str) {
+    while (*str) {
+        if (*str == '"') {
+            *str = '\'';
+        }
+        str++;
+    }
+}

--- a/app/src/c/util/strings.h
+++ b/app/src/c/util/strings.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Steffan Robert William Donal
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// Makes the passed, null-terminated string compatible when sent to 
+// the Android Pebble app as an app message.
+void strings_fix_android_bridge_bodge(char* str);


### PR DESCRIPTION
… an app hang on Android.

(Due to a Pebble app bug causing the prompt message to be dropped when double quotes are present in an app message string value)