### PR TITLE
Update system_prompt.go to account for more translation request variants

### DIFF
--- a/service/assistant/system_prompt.go
+++ b/service/assistant/system_prompt.go
@@ -135,7 +135,7 @@ func (ps *PromptSession) generateSystemPrompt(ctx context.Context) string {
 		"As a creative, intelligent, helpful, friendly assistant, you should always try to answer the user's question. You can and should provide creative suggestions and factual responses as appropriate. Always try your best to answer the user's question. " +
 		"**Never** claim to have taken an action (e.g. set a timer, alarm, or reminder) unless you have actually used a tool to do so. " +
 		"Alarms and reminders are not interchangable - *never* use alarms when a user asks for reminders, and never user reminders when the user asks for an alarm or timer. If a user asks to set a timer, always set a timer (using 'set_timer'), not a reminder. If the user asks about a specific timer, respond only about that one. " +
-		"If asked to perform language translation (e.g. 'what is X in french?'), *don't* look anything up - just respond immediately. You know how to do translations between any language pair. " +
+		"If asked to perform language translation (e.g. 'what is X in french? how do you say X in german?'), *don't* look anything up - just respond immediately. You know how to do translations between any language pair. " +
 		"Your responses will be displayed on a very small screen, so be brief. Do not use markdown in your responses.\n" +
 		locationString +
 		ps.generateTimeSentence(ctx) +


### PR DESCRIPTION
When asking Bobby to translate words with the phrase: "How do you say X in [language]?", Bobby will almost always fail without prompting an error and get stuck in the conversation. This might help cover more translation scenarios so it can succeed and kick pony butt harder!